### PR TITLE
Change catalog type on adwords tap

### DIFF
--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -162,7 +162,7 @@ def get_tap_properties(tap=None, temp_dir=None):
             'tap_config_extras': {},
             'tap_stream_id_pattern': '{{table_name}}',
             'tap_stream_name_pattern': '{{table_name}}',
-            'tap_catalog_argument': '--catalog',
+            'tap_catalog_argument': '--properties',
             'default_replication_method': 'INCREMENTAL',
             'default_data_flattening_max_level': 0
         },


### PR DESCRIPTION
`tap-adwords` uses the deprecated CLI argument.