### PR TITLE
Update mysql_to_redshift.py

### DIFF
--- a/pipelinewise/fastsync/mysql_to_redshift.py
+++ b/pipelinewise/fastsync/mysql_to_redshift.py
@@ -56,7 +56,7 @@ def tap_type_to_target_type(mysql_type, mysql_column_type):
         else 'NUMERIC NULL',
         'smallint': 'NUMERIC NULL',
         'mediumint': 'NUMERIC NULL',
-        'bigint': 'NUMERIC NULL',
+        'bigint': 'BIGINT NULL',
         'bit': 'BOOLEAN',
         'decimal': 'FLOAT',
         'double': 'FLOAT',


### PR DESCRIPTION
Redshift target datatype should be bigint

## Problem

Redshift type is set to Numeric for MySQL bigint type. This can cause numeric overflow.

## Proposed changes

Using Bigint on Redshift as well.

## Types of changes

